### PR TITLE
ENH: Add equivalence to SQS object

### DIFF
--- a/prlworkflows/sqs.py
+++ b/prlworkflows/sqs.py
@@ -186,6 +186,21 @@ class SQS(Structure):
         self.sublattice_site_ratios = kwargs.pop('sublattice_site_ratios', None)
         super(SQS, self).__init__(*args, **kwargs)
 
+    def __eq__(self, other):
+        """
+        self and other are equivalent if the sublattice models are equal
+
+        Parameters
+        ----------
+        other : SQS
+        """
+        if not isinstance(other, SQS):
+            return False
+        subl_config = self.sublattice_configuration == other.sublattice_configuration
+        subl_site_ratios = self.sublattice_site_ratios == other.sublattice_site_ratios
+        subl_occupancies = self.sublattice_occupancies == other.sublattice_occupancies
+        return subl_config and subl_site_ratios and subl_occupancies
+
     @property
     def espei_sublattice_configuration(self):
         """

--- a/prlworkflows/tests/test_sqs.py
+++ b/prlworkflows/tests/test_sqs.py
@@ -443,3 +443,20 @@ def test_equality_of_sqs_objects_with_different_indexing():
     s2 = SQS(Lattice.hexagonal(1, 2), ['Mg', 'Mg'], [[0,0,0], [0.3333, 0.66666, 0.5]], sublattice_configuration=config_2, sublattice_occupancies=occupancy_2, sublattice_site_ratios=site_ratios_2)
 
     assert s1 == s2
+
+@pytest.mark.skip
+def test_equality_of_sqs_objects_with_different_subl_ordering():
+    """SQS structures that are the same, but are ordered differently within a sublattice should be equal."""
+    # TODO: implement this behavior in SQS.__eq__
+    config_1 = [['A', 'B'], ['A']]
+    occupancy_1 = [[0.25, 0.75], [1]]
+    site_ratios_1 = [3, 1]
+
+    config_2 = [['B', 'A'], ['A']]
+    occupancy_2 = [[0.75, 0.25], [1]]
+    site_ratios_2 = [3, 1]
+
+    s1 = SQS(Lattice.hexagonal(1, 2), ['Mg', 'Mg'], [[0,0,0], [0.3333, 0.66666, 0.5]], sublattice_configuration=config_1, sublattice_occupancies=occupancy_1, sublattice_site_ratios=site_ratios_1)
+    s2 = SQS(Lattice.hexagonal(1, 2), ['Mg', 'Mg'], [[0,0,0], [0.3333, 0.66666, 0.5]], sublattice_configuration=config_2, sublattice_occupancies=occupancy_2, sublattice_site_ratios=site_ratios_2)
+
+    assert s1 == s2

--- a/prlworkflows/tests/test_sqs.py
+++ b/prlworkflows/tests/test_sqs.py
@@ -426,3 +426,20 @@ def test_equality_of_sqs_objects():
     s1.sublattice_configuration = config
 
     assert s1 == s2
+
+@pytest.mark.skip
+def test_equality_of_sqs_objects_with_different_indexing():
+    """SQS structures that are the same, but indexed differently should be equal."""
+    # TODO: implement this behavior in SQS.__eq__
+    config_1 = [['A', 'B'], ['A']]
+    occupancy_1 = [[0.25, 0.75], [1]]
+    site_ratios_1 = [3, 1]
+
+    config_2 = [['A'], ['A', 'B']]
+    occupancy_2 = [[1], [0.25, 0.75]]
+    site_ratios_2 = [1, 3]
+
+    s1 = SQS(Lattice.hexagonal(1, 2), ['Mg', 'Mg'], [[0,0,0], [0.3333, 0.66666, 0.5]], sublattice_configuration=config_1, sublattice_occupancies=occupancy_1, sublattice_site_ratios=site_ratios_1)
+    s2 = SQS(Lattice.hexagonal(1, 2), ['Mg', 'Mg'], [[0,0,0], [0.3333, 0.66666, 0.5]], sublattice_configuration=config_2, sublattice_occupancies=occupancy_2, sublattice_site_ratios=site_ratios_2)
+
+    assert s1 == s2

--- a/prlworkflows/tests/test_sqs.py
+++ b/prlworkflows/tests/test_sqs.py
@@ -400,3 +400,29 @@ def test_sqs_finds_correct_endmember_symmetry():
 
     rocksalt_b1 = lat_in_to_sqs(ATAT_ROCKSALT_B1_LATTICE_IN)
     assert rocksalt_b1.get_endmember_space_group_info()[0] == 'Fm-3m'
+
+
+def test_equality_of_sqs_objects():
+    """SQS structures with different underlying crystal structures are equivalent iff sublattice models are equivalent."""
+    config = [['A', 'B'], ['A']]
+    occupancy = [[0.5, 0.5], [1]]
+    site_ratios = [3, 1]
+    # Use same sublattice for different underlying structures. Should be equal
+    s1 = SQS(Lattice.hexagonal(1, 2), ['Mg', 'Mg'], [[0,0,0], [0.3333, 0.66666, 0.5]], sublattice_configuration=config, sublattice_occupancies=occupancy, sublattice_site_ratios=site_ratios)
+    s2 = SQS(Lattice.cubic(1), ['Fe'], [[0,0,0]], sublattice_configuration=config, sublattice_occupancies=occupancy, sublattice_site_ratios=site_ratios)
+    assert s1 == s2
+
+    # Use same underlying crystal structures, but different sublattice configurations. Should be not equal
+    s1.sublattice_site_ratios = [2, 1]
+    assert s1 != s2
+    s1.sublattice_site_ratios = site_ratios
+
+    s1.sublattice_occupancies = [[0.25, 0.5], [1]]
+    assert s1 != s2
+    s1.sublattice_occupancies = occupancy
+
+    s1.sublattice_configuration = [['A', 'A'], ['A']]
+    assert s1 != s2
+    s1.sublattice_configuration = config
+
+    assert s1 == s2


### PR DESCRIPTION
Equivalence is tested by checking that the sublattice configuration, occupancies, and site ratios are equal.

This does not handle cases where the indices of the sublattices are different:
```
    config_1 = [['A', 'B'], ['A']]
    occupancy_1 = [[0.25, 0.75], [1]]
    site_ratios_1 = [3, 1]

    config_2 = [['A'], ['A', 'B']]
    occupancy_2 = [[1], [0.25, 0.75]]
    site_ratios_2 = [1, 3]
```

or cases where the case where the elements in a sublattice are ordered differently:

```
    config_1 = [['A', 'B'], ['A']]
    occupancy_1 = [[0.25, 0.75], [1]]
    site_ratios_1 = [3, 1]

    config_2 = [['B', 'A'], ['A']]
    occupancy_2 = [[0.75, 0.25], [1]]
    site_ratios_2 = [3, 1]
```

But there are failing (skipped) tests to verify this behavior